### PR TITLE
support for variable lookup from environment and .env file

### DIFF
--- a/pkg/transformers/kubernetes/generate.go
+++ b/pkg/transformers/kubernetes/generate.go
@@ -43,6 +43,9 @@ func Generate(vals *types.CmdValues) (*kapi.List, error) {
 		ComposeFiles: paths,
 	}
 	p := project.NewProject(context)
+	if err := project.AddEnvironmentLookUp(context); err != nil {
+		return nil, err
+	}
 	if err := p.Parse(); err != nil {
 		return nil, err
 	}

--- a/pkg/transformers/openshift/generate.go
+++ b/pkg/transformers/openshift/generate.go
@@ -54,6 +54,9 @@ func Generate(vals *types.CmdValues) (*templateapi.Template, error) {
 		ComposeFiles: paths,
 	}
 	p := project.NewProject(context)
+	if err := project.AddEnvironmentLookUp(context); err != nil {
+		return nil, err
+	}
 	if err := p.Parse(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now environment variables in docker compose file can be substituted from the operating system environment or .env file.

This has been merged in upstream https://github.com/openshift/origin/pull/9316

fixes issue #13 