### PR TITLE
Accept multiple ports in interactive mode

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/openshift/origin/third_party/github.com/docker/libcompose/project"
 )
@@ -21,12 +23,18 @@ func CheckIfFileExists(files []string) error {
 	return nil
 }
 
+// getInput is a generic function that takes a prompt string and scans a line
+// and always returns string, caller has to parse the value to the required type
 func getInput(prompt string) (response string) {
 	fmt.Fprintf(os.Stdout, prompt)
-	fmt.Scanf("%s", &response)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	response = scanner.Text()
 	return
 }
 
+// AskForData loops on the parsed docker-compose file's config and the data that is missing will be queried
+// interactively to user
 func AskForData(config map[string]*project.ServiceConfig) {
 	for svc := range config {
 
@@ -34,8 +42,13 @@ func AskForData(config map[string]*project.ServiceConfig) {
 		if len(config[svc].Ports) == 0 {
 			msg := fmt.Sprintf("[%s] No ports defined to send traffic to, no provider service will be created. Do you want to create a service? y/[n]: ", svc)
 			if resp := getInput(msg); resp == "y" {
-				msg = fmt.Sprintf("[%s] Enter ports: ", svc)
-				config[svc].Ports = append(config[svc].Ports, getInput(msg))
+				msg = fmt.Sprintf("[%[1]s] Note: Ports should of the form '8080' or '13306:3306' or '18888:8888 3306'\n[%[1]s] Enter ports : ", svc)
+
+				// user can provide multiple ports separated by space
+				// for e.g. "3306 18080:8080 7878"
+				for _, port := range strings.Split(getInput(msg), " ") {
+					config[svc].Ports = append(config[svc].Ports, port)
+				}
 			}
 		}
 


### PR DESCRIPTION
Now user can specify multiple ports in interactive mode separated by space.

e.g.
```
[mariadb] No ports defined to send traffic to, no provider service will be created. Do you want to create a service? y/[n]: y
[mariadb] Note: Ports should of the form '8080' or '13306:3306' or '18888:8888 3306'
[mariadb] Enter ports: 3306 4455:4455 7788:7788
```
It will create ports in `mariadb` service like this

```
    ports:
    - name: 3306-tcp
      port: 3306
      targetPort: 3306
    - name: 4455-tcp
      port: 4455
      targetPort: 4455
    - name: 7788-tcp
      port: 7788
      targetPort: 7788
```

Fixes #30 