### PR TITLE
Save converted output to file with -o option

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -50,6 +50,7 @@ func Execute() (*types.CmdValues, error) {
 	RootCmd.Flags().BoolVarP(&val.Interactive, "interactive", "i", false, "Ask questions about values that can affect conversion.")
 	RootCmd.Flags().StringSliceVarP(&val.Files, "files", "f", []string{"docker-compose.yml"}, "Provide docker-compose files, comma separated.")
 	RootCmd.Flags().IntVarP(&val.Loglevel, "loglevel", "", 0, "Log level to show.")
+	RootCmd.Flags().StringVarP(&val.OutputFile, "output-file", "o", "", "File to save converted artifacts.")
 
 	if err := RootCmd.Execute(); err != nil {
 		return nil, err

--- a/pkg/transformers/main.go
+++ b/pkg/transformers/main.go
@@ -18,14 +18,20 @@ func Transform(vals *types.CmdValues) error {
 		if err != nil {
 			return err
 		}
-		kubernetes.PrintList(list)
+		err = kubernetes.PrintList(list, vals)
+		if err != nil {
+			return err
+		}
 		return nil
 	case "kubernetes":
 		list, err := kubernetes.Transform(vals)
 		if err != nil {
 			return err
 		}
-		kubernetes.PrintList(list)
+		err = kubernetes.PrintList(list, vals)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 	err := fmt.Errorf("Provider not supported")

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,4 +5,5 @@ type CmdValues struct {
 	Interactive bool
 	Files       []string
 	Loglevel    int
+	OutputFile  string
 }


### PR DESCRIPTION
Usage:
```
$ ./henge openshift --output-file ./output1
```
AND
```
$ ./henge openshift -o ./output
```