### PR TITLE
Script for cross compiling for multiple platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# ./hack/build-cross.sh output
+bin

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#
+# Script for cross compiling Henge for multiple platforms.
+#
+
+HENGE_ROOT=$(dirname "${BASH_SOURCE}")/..
+BUILD_DIR=${HENGE_ROOT}/bin
+
+# Platforms and architectures we want to build for
+PLATFORMS=${1:-"darwin linux windows"}
+ARCHS=${2:-"amd64"}
+
+echo "Staring builds"
+
+for platform in $PLATFORMS; do
+  for arch in $ARCHS; do
+    echo " Building for ${platform}/${arch}"
+    OUTPUT_FILE=${BUILD_DIR}/${platform}/${arch}/henge
+    GOOS=$platform GARCH=$arch go build -o ${OUTPUT_FILE}
+  done
+done
+
+echo "Builds finished"
+echo "Binaries are in `readlink -f ${BUILD_DIR}`/"


### PR DESCRIPTION
This adds script `./hack/build-cross.sh` that makes easy to build Henge binary for multiple platforms.

fixes #38 

and related to #36