### PR TITLE
[WIP] Create nightly builds and upload them to public Dropbox folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
     - 1.6
 
 install:
-    - go install 
+    - go install
 
 script:
     - test/cmd/henge.sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Project goals:
 - The tool can be used as a library or service with another front end e.g. oc, kubectl, a web app or an IDE.
 
 
+## Releases
+
+We don't have any releases yet.
+But if you don't want to compile henge yourself, you can download latest master build - [Henge master builds](https://www.dropbox.com/sh/lcz3o5o0i0gv6fw/AADMZrz7URk0R6qkKnyE7Hs7a?dl=0) 
 
 ## Usage
 

--- a/hack/upload-master-builds-to-dropbox.sh
+++ b/hack/upload-master-builds-to-dropbox.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This uploads cross compiled binaries to Dropbox
+# https://www.dropbox.com/sh/lcz3o5o0i0gv6fw/AADMZrz7URk0R6qkKnyE7Hs7a?dl=0
+
+
+# This should be set outside of this script in some secure way
+# DROPBOX_TOKEN=
+
+SHORT_COMMIT=`echo $TRAVIS_COMMIT | cut -c1-8`
+
+PLATFORMS="darwin linux windows"
+ARCHS="amd64"
+
+
+upload_file() {
+  SOURCE=$1
+  TARGET=$2
+
+  curl -X POST https://content.dropboxapi.com/2/files/upload \
+    --header "Authorization: Bearer ${DROPBOX_TOKEN}" \
+    --header "Content-Type: application/octet-stream" \
+    --header "Dropbox-API-Arg: {\"path\":\"${TARGET}\",\"autorename\":true}" \
+    --data-binary @"${SOURCE}"
+
+}
+
+#record commit id
+echo $TRAVIS_COMMIT > "commitid"
+
+
+for platform in $PLATFORMS; do
+  for arch in $ARCHS; do
+    # upload binary
+    upload_file "bin/${platform}/${arch}/henge" "/HengeMasterBuilds/${platform}/${arch}/henge-latest"
+    upload_file "build-from" "/HengeMasterBuilds/${platform}/${arch}/commitid"
+  done
+done


### PR DESCRIPTION
I had idea that it would be nice to have something like nightly builds :-)

Dropbox just because it was first think that I could think of for file sharing.

This adds script that automatically uploads binaries for multiple platforms to public directory on Dropbox.
Resulted binaries are accessible to anyone at https://www.dropbox.com/sh/lcz3o5o0i0gv6fw/AADMZrz7URk0R6qkKnyE7Hs7a?dl=0

depends on: #46 