### PR TITLE
Better error messages on file not found

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -14,10 +14,10 @@ func CheckIfFileExists(files []string) error {
 	for _, filename := range files {
 		fileInfo, err := os.Stat(filename)
 		if err != nil {
-			return fmt.Errorf("file %q not found", filename)
+			return err
 		}
 		if fileInfo.IsDir() {
-			return fmt.Errorf("%q is a directory", filename)
+			return fmt.Errorf("%s: must be a file not a directory", filename)
 		}
 	}
 	return nil


### PR DESCRIPTION
So `os.Stat` itself gives error of what operation was being performed, filename and error. So we don't need to frame it ourselves, but with directory check we need to frame an error.

If file not found
```
henge kubernetes
stat docker-compose.yml: no such file or directory
```

If file is a directory
```
henge kubernetes -f ./complex
check ./complex: is a directory
```